### PR TITLE
Add support for `==` operator on Termios

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -33,7 +33,7 @@ mod os {
   #[allow(non_camel_case_types)]
   pub type tcflag_t = c_uint;
 
-  #[derive(Debug,Copy)]
+  #[derive(Debug,Copy,Eq,PartialEq)]
   #[repr(C)]
   pub struct Termios {
     pub c_iflag: tcflag_t,
@@ -219,7 +219,7 @@ mod os {
   #[allow(non_camel_case_types)]
   pub type speed_t = c_ulong;
 
-  #[derive(Show,Copy)]
+  #[derive(Show,Copy,Eq,PartialEq)]
   #[repr(C)]
   pub struct Termios {
     pub c_iflag: tcflag_t,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,3 @@
-#[allow(unstable)]
 extern crate libc;
 use self::libc::{c_void,c_int};
 
@@ -23,10 +22,7 @@ extern "C" {
 
 #[cfg(target_os = "linux")]
 mod os {
-  #[allow(unstable)]
-  extern crate libc;
-
-  use self::libc::{c_int,c_uint,c_uchar};
+  use super::libc::{c_int,c_uint,c_uchar};
 
   #[allow(non_camel_case_types)]
   pub type cc_t = c_uchar;
@@ -37,7 +33,7 @@ mod os {
   #[allow(non_camel_case_types)]
   pub type tcflag_t = c_uint;
 
-  #[derive(Show,Copy)]
+  #[derive(Debug,Copy)]
   #[repr(C)]
   pub struct Termios {
     pub c_iflag: tcflag_t,
@@ -212,10 +208,7 @@ mod os {
 
 #[cfg(target_os = "macos")]
 mod os {
-  #[allow(unstable)]
-  extern crate libc;
-
-  use self::libc::{c_int,c_uchar,c_ulong};
+  use super::libc::{c_int,c_uchar,c_ulong};
 
   #[allow(non_camel_case_types)]
   pub type tcflag_t = c_ulong;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
-#[allow(unstable)]
 extern crate libc;
 
 use self::libc::{c_int};
-use std::io::{IoError,IoResult};
+use std::old_io::{IoError,IoResult};
 use std::mem;
 use std::default::Default;
 
@@ -93,7 +92,6 @@ pub fn cfsetspeed(termios: &mut Termios, speed: speed_t) -> IoResult<()> {
 
 
 #[inline]
-#[allow(unstable)]
 fn io_result(result: c_int) -> IoResult<()> {
   match result {
     0 => Ok(()),


### PR DESCRIPTION
Hi David,

Thanks a lot for publishing these bindings. These save me a lot of time! :smiley: 

The current code does not compile with the latest rustc. In this PR, I make some minor changes so it compiles again. The changes include removing the `#[allow(unstable)]` lint, which [has been removed](http://stackoverflow.com/a/28238491). And I remove some `extern crate libc` lines which seem unnecessary.

Finally, I added support for using the `==` operator on `Termios` structs. This comes in handy for testing: for instance, if a library changes the TTY settings, I can test that the original TTY state is restored correctly with the `==` operator at the end of the test.

Please let me know if you have any questions :wink: 

Best regards,
Conrad