### PR TITLE
Put libc as a ext dependency to compile with rust-beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "termios"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["David Cuddeback <david.cuddeback@gmail.com>"]
 description = "Safe bindings for the termios library."
 license = "MIT"
@@ -9,3 +9,6 @@ homepage = "https://github.com/dcuddeback/termios-rs"
 repository = "https://github.com/dcuddeback/termios-rs.git"
 readme = "README.md"
 keywords = ["termios", "tty", "terminal", "posix"]
+
+[dependencies]
+libc = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -19,20 +19,18 @@ Add `termios` as a dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-termios = "0.0.4"
+termios = "0.0.5"
+libc = "0.1.5"
 ```
 
 Import the `termios` crate and any symbols needed from `termios`. You will also probably need
 `libc::c_int` for file descriptors and `std::io::Result` to propagate errors.
 
 ```rust
-#![feature(libc)]
-
 extern crate termios;
 extern crate libc;
 
 use std::io;
-
 use libc::c_int;
 use termios::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(libc)]
-
 extern crate libc;
 
 use std::io;


### PR DESCRIPTION
At the moment, the lib doesn't compile on rust-beta anymore. This should fix it.