### PR TITLE
Add support for DragonFlyBSD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,11 @@
 //!     cfsetspeed(termios, termios::os::freebsd::B921600)
 //! }
 //!
+//! #[cfg(target_os = "dragonfly")]
+//! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
+//!     cfsetspeed(termios, termios::os::dragonfly::B921600)
+//! }
+//!
 //! #[cfg(target_os = "openbsd")]
 //! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
 //!     cfsetspeed(termios, termios::os::openbsd::B921600)

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -3,9 +3,11 @@
 #[cfg(target_os = "linux")] pub use self::linux as target;
 #[cfg(target_os = "macos")] pub use self::macos as target;
 #[cfg(target_os = "freebsd")] pub use self::freebsd as target;
+#[cfg(target_os = "dragonfly")] pub use self::dragonfly as target;
 #[cfg(target_os = "openbsd")] pub use self::openbsd as target;
 
 #[cfg(target_os = "linux")] pub mod linux;
 #[cfg(target_os = "macos")] pub mod macos;
 #[cfg(target_os = "freebsd")] pub mod freebsd;
+#[cfg(target_os = "dragonfly")] #[path = "freebsd.rs"] pub mod dragonfly;
 #[cfg(target_os = "openbsd")] pub mod openbsd;


### PR DESCRIPTION
Reuse the freebsd module, but export it as "dragonfly".
