### PR TITLE
Add preliminary Android support

### DIFF
--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,10 +1,12 @@
 //! OS-specific definitions.
 
+#[cfg(target_os = "android")] pub use self::linux as target;
 #[cfg(target_os = "linux")] pub use self::linux as target;
 #[cfg(target_os = "macos")] pub use self::macos as target;
 #[cfg(target_os = "freebsd")] pub use self::freebsd as target;
 #[cfg(target_os = "openbsd")] pub use self::openbsd as target;
 
+#[cfg(target_os = "android")] pub mod linux;
 #[cfg(target_os = "linux")] pub mod linux;
 #[cfg(target_os = "macos")] pub mod macos;
 #[cfg(target_os = "freebsd")] pub mod freebsd;


### PR DESCRIPTION
This builds using `cargo build --target=arm-linux-androideabi --verbose`. From a quick internet search it looks like the termios is supported by the kernel on Android, but I haven't run this yet.