### PR TITLE
Make `c_ispeed` and `c_ospeed` public.

### DIFF
--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -17,8 +17,8 @@ pub struct termios {
     pub c_lflag: tcflag_t,
     c_line: cc_t,
     pub c_cc: [cc_t; NCCS],
-    c_ispeed: speed_t,
-    c_ospeed: speed_t
+    pub c_ispeed: speed_t,
+    pub c_ospeed: speed_t,
 }
 
 pub const NCCS: usize = 32;


### PR DESCRIPTION
Access to these fields is important when setting custom transmission
rates; make them accessible for other libraries.

This PR is in anticipation of a new feature for serial-rs, allowing custom bitrates to be set.