### PR TITLE
Public rates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ keywords = ["termios", "tty", "terminal", "posix"]
 
 [dependencies]
 libc = "0.2"
+ioctl-rs = "0.1.5"

--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -178,3 +178,7 @@ pub const TCIOFLUSH: c_int = 2;
 pub const TCSANOW:   c_int = 0;
 pub const TCSADRAIN: c_int = 1;
 pub const TCSAFLUSH: c_int = 2;
+
+// ioctls should be a c_uint, not a c_int. the warning cause by this should
+// be ignore until the bug in ioctl-rs is fixed.
+pub const TCGETS2: c_int = (0x802c_542a as c_int);

--- a/src/os/linux.rs
+++ b/src/os/linux.rs
@@ -17,8 +17,8 @@ pub struct termios {
     pub c_lflag: tcflag_t,
     c_line: cc_t,
     pub c_cc: [cc_t; NCCS],
-    c_ispeed: speed_t,
-    c_ospeed: speed_t
+    pub c_ispeed: speed_t,
+    pub c_ospeed: speed_t,
 }
 
 pub const NCCS: usize = 32;


### PR DESCRIPTION
Formerly #8. Now includes correct `ioctl`.

Warnings will disappear if https://github.com/dcuddeback/ioctl-rs/issues/3 is fixed.