### PR TITLE
Add illumos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ termios definitions for the following platforms:
 * FreeBSD (amd64)
 * OpenBSD (amd64)
 * DragonFly BSD (x86_64)
+* illumos (x86_64)
 
 ## Usage
 Add `termios` as a dependency in `Cargo.toml`:

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -10,11 +10,34 @@ extern "C" {
     pub fn tcdrain(fd: c_int) -> c_int;
     pub fn tcflush(fd: c_int, queue_selector: c_int) -> c_int;
     pub fn tcflow(fd: c_int, action: c_int) -> c_int;
+    #[cfg(not(target_os = "solaris"))]
     pub fn cfmakeraw(termios_p: *mut ::os::target::termios);
     pub fn cfgetispeed(termios_p: *const ::os::target::termios) -> ::os::target::speed_t;
     pub fn cfgetospeed(termios_p: *const ::os::target::termios) -> ::os::target::speed_t;
     pub fn cfsetispeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
     pub fn cfsetospeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
+    #[cfg(not(target_os = "solaris"))]
     pub fn cfsetspeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
     pub fn tcgetsid(fd: c_int) -> pid_t;
+}
+
+#[cfg(target_os = "solaris")]
+pub unsafe fn cfmakeraw(termios: *mut ::os::target::termios) {
+    use ::os::target::{IMAXBEL, IGNBRK, BRKINT, PARMRK, ISTRIP, INLCR, IGNCR, ICRNL, IXON, OPOST,
+        ECHO, ECHONL, ICANON, ISIG, IEXTEN, CSIZE, PARENB, CS8};
+    let mut t = *termios as ::os::target::termios;
+    t.c_iflag &= !(IMAXBEL|IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL|IXON);
+    t.c_oflag &= !OPOST;
+    t.c_lflag &= !(ECHO|ECHONL|ICANON|ISIG|IEXTEN);
+    t.c_cflag &= !(CSIZE|PARENB);
+    t.c_cflag |= CS8;
+}
+
+#[cfg(target_os = "solaris")]
+pub unsafe fn cfsetspeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int {
+    let ret = cfsetispeed(termios_p, speed);
+    if ret != 0 {
+        return ret;
+    }
+    cfsetospeed(termios_p, speed)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,11 @@
 //!     cfsetspeed(termios, termios::os::dragonfly::B230400)
 //! }
 //!
+//! #[cfg(target_os = "solaris")]
+//! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
+//!     cfsetspeed(termios, termios::os::solaris::B921600)
+//! }
+//!
 //! # let fd = 1;
 //! let mut termios = Termios::from_fd(fd).unwrap();
 //! set_fastest_speed(&mut termios).unwrap();

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(target_os = "freebsd")] pub use self::freebsd as target;
 #[cfg(target_os = "openbsd")] pub use self::openbsd as target;
 #[cfg(target_os = "dragonfly")] pub use self::dragonfly as target;
+#[cfg(target_os = "solaris")] pub use self::solaris as target;
 
 #[cfg(target_os = "linux")] pub mod linux;
 #[cfg(target_os = "android")] pub mod android;
@@ -13,3 +14,4 @@
 #[cfg(target_os = "freebsd")] pub mod freebsd;
 #[cfg(target_os = "openbsd")] pub mod openbsd;
 #[cfg(target_os = "dragonfly")] pub mod dragonfly;
+#[cfg(target_os = "solaris")] pub mod solaris;

--- a/src/os/solaris.rs
+++ b/src/os/solaris.rs
@@ -1,0 +1,143 @@
+#![allow(non_camel_case_types)]
+
+use libc::{c_uint,c_uchar};
+
+pub const NCCS: usize = 19;
+
+pub type cc_t = c_uchar;
+pub type speed_t = c_uint;
+pub type tcflag_t = c_uint;
+
+#[derive(Debug,Copy,Clone,Eq,PartialEq)]
+#[repr(C)]
+pub struct termios {
+    pub c_iflag: ::tcflag_t,
+    pub c_oflag: ::tcflag_t,
+    pub c_cflag: ::tcflag_t,
+    pub c_lflag: ::tcflag_t,
+    pub c_cc: [cc_t; NCCS]
+}
+
+
+// c_cc characters
+pub const VINTR: usize = 0;
+pub const VQUIT: usize = 1;
+pub const VERASE: usize = 2;
+pub const VKILL: usize = 3;
+pub const VEOF: usize = 4;
+pub const VEOL: usize = 5;
+pub const VEOL2: usize = 6;
+pub const VMIN: usize = 4;
+pub const VTIME: usize = 5;
+pub const VSWTCH: usize = 7;
+pub const VSTART: usize = 8;
+pub const VSTOP: usize = 9;
+pub const VSUSP: usize = 10;
+pub const VDSUSP: usize = 11;
+pub const VREPRINT: usize = 12;
+pub const VDISCARD: usize = 13;
+pub const VWERASE: usize = 14;
+pub const VLNEXT: usize = 15;
+pub const VSTATUS: usize = 16;
+pub const VERASE2: usize = 17;
+
+// c_iflag bits
+pub const IGNBRK: ::tcflag_t = 0o0001;
+pub const BRKINT: ::tcflag_t = 0o0002;
+pub const IGNPAR: ::tcflag_t = 0o0004;
+pub const PARMRK: ::tcflag_t = 0o0010;
+pub const INPCK: ::tcflag_t = 0o0020;
+pub const ISTRIP: ::tcflag_t = 0o0040;
+pub const INLCR: ::tcflag_t = 0o0100;
+pub const IGNCR: ::tcflag_t = 0o0200;
+pub const ICRNL: ::tcflag_t = 0o0400;
+pub const IXON: ::tcflag_t = 0o2000;
+pub const IXOFF: ::tcflag_t = 0o010_000;
+pub const IXANY: ::tcflag_t = 0o04000;
+pub const IMAXBEL: ::tcflag_t = 0o020_000;
+
+// c_oflag bits
+pub const OPOST: ::tcflag_t = 0o0001;
+pub const ONLCR: ::tcflag_t = 0o0004;
+pub const OCRNL: ::tcflag_t = 0o0010;
+pub const ONOCR: ::tcflag_t = 0o0020;
+pub const ONLRET: ::tcflag_t = 0o0040;
+
+// c_cflag bits
+pub const CSIZE: ::tcflag_t = 0o0060;
+pub const CS5: ::tcflag_t = 0;
+pub const CS6: ::tcflag_t = 0o0020;
+pub const CS7: ::tcflag_t = 0o0040;
+pub const CS8: ::tcflag_t = 0o0060;
+pub const CSTOPB: ::tcflag_t = 0o0100;
+pub const CREAD: ::tcflag_t = 0o0200;
+pub const PARENB: ::tcflag_t = 0o0400;
+pub const PARODD: ::tcflag_t = 0o01000;
+pub const HUPCL: ::tcflag_t = 0o02000;
+pub const CLOCAL: ::tcflag_t = 0o04000;
+
+// c_lflag bits
+pub const ECHO: ::tcflag_t = 0o0010;
+pub const ECHOE: ::tcflag_t = 0o0020;
+pub const ECHOK: ::tcflag_t = 0o0040;
+pub const ECHONL: ::tcflag_t = 0o0100;
+pub const ECHOCTL: ::tcflag_t = 0o01000;
+pub const ECHOPRT: ::tcflag_t = 0o02000;
+pub const ECHOKE: ::tcflag_t = 0o04000;
+pub const EXTPROC: ::tcflag_t = 0o200_000;
+pub const ISIG: ::tcflag_t = 0o0001;
+pub const ICANON: ::tcflag_t = 0o0002;
+pub const IEXTEN: ::tcflag_t = 0o100_000;
+pub const TOSTOP: ::tcflag_t = 0o0400;
+pub const FLUSHO: ::tcflag_t = 0o020_000;
+pub const PENDIN: ::tcflag_t = 0o040_000;
+pub const NOFLSH: ::tcflag_t = 0o0200;
+
+// baud rates
+pub const B0: speed_t = 0;
+pub const B50: speed_t = 1;
+pub const B75: speed_t = 2;
+pub const B110: speed_t = 3;
+pub const B134: speed_t = 4;
+pub const B150: speed_t = 5;
+pub const B200: speed_t = 6;
+pub const B300: speed_t = 7;
+pub const B600: speed_t = 8;
+pub const B1200: speed_t = 9;
+pub const B1800: speed_t = 10;
+pub const B2400: speed_t = 11;
+pub const B4800: speed_t = 12;
+pub const B9600: speed_t = 13;
+pub const B19200: speed_t = 14;
+pub const B38400: speed_t = 15;
+pub const B57600: speed_t = 16;
+pub const B76800: speed_t = 17;
+pub const B115200: speed_t = 18;
+pub const B153600: speed_t = 19;
+pub const B230400: speed_t = 20;
+pub const B307200: speed_t = 21;
+pub const B460800: speed_t = 22;
+pub const B921600: speed_t = 23;
+
+pub const B7200:   speed_t = 7200;
+pub const B14400:  speed_t = 14400;
+pub const B28800:  speed_t = 28800;
+pub const EXTA:    speed_t = B19200;
+pub const EXTB:    speed_t = B38400;
+
+// tcflow()
+pub const TCOOFF: ::c_int = 0;
+pub const TCOON: ::c_int = 1;
+pub const TCIOFF: ::c_int = 2;
+pub const TCION: ::c_int = 3;
+
+// tcflush()
+pub const TCIFLUSH: ::c_int = 0;
+pub const TCOFLUSH: ::c_int = 1;
+pub const TCIOFLUSH: ::c_int = 2;
+
+// tcsetattr()
+const _TIOC: ::c_int = ('T' as i32) << 8;
+pub const TCSANOW: ::c_int = (_TIOC|14);
+pub const TCSADRAIN: ::c_int = (_TIOC|15);
+pub const TCSAFLUSH: ::c_int = (_TIOC|16);


### PR DESCRIPTION
While trying to build `bat` on a SmartOS system, I found that termios currently doesn't support illumos.

```
root - rustdev ~/src/termios-rs (git:mz-illumos) # cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running target/debug/deps/termios-e986a12baa34d741

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests termios

running 10 tests
test src/lib.rs -  (line 44) ... ok
test src/lib.rs -  (line 19) ... ok
test src/lib.rs - Termios (line 152) ... ok
test src/lib.rs -  (line 78) ... ok
test src/lib.rs -  (line 28) ... ok
test src/lib.rs - cfsetspeed (line 361) ... ok
test src/lib.rs - cfgetispeed (line 221) ... ok
test src/lib.rs - cfgetospeed (line 236) ... ok
test src/lib.rs - cfsetispeed (line 278) ... ok
test src/lib.rs - cfsetospeed (line 321) ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

This should support other Solaris based systems, but I sourced all of the header translations from illumos and I am unable to test on Oracle Solaris.  Also I would have just named the target "illumos", but this [issue](https://github.com/rust-lang/rust/issues/55553) is still being sorted out.