### PR TITLE
Add NetBSD support (mostly copy OpenBSD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ termios definitions for the following platforms:
 * OS X (x86_64)
 * FreeBSD (amd64)
 * OpenBSD (amd64)
+* NetBSD (amd64)
 * DragonFly BSD (x86_64)
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!
 //! #[cfg(target_os = "netbsd")]
 //! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
-//!     cfsetspeed(termios, termios::os::netbsd::B9600)
+//!     cfsetspeed(termios, termios::os::netbsd::B921600)
 //! }
 //! #[cfg(target_os = "dragonfly")]
 //! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,10 @@
 //!     cfsetspeed(termios, termios::os::openbsd::B921600)
 //! }
 //!
+//! #[cfg(target_os = "netbsd")]
+//! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
+//!     cfsetspeed(termios, termios::os::netbsd::B9600)
+//! }
 //! #[cfg(target_os = "dragonfly")]
 //! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
 //!     cfsetspeed(termios, termios::os::dragonfly::B230400)

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -5,6 +5,7 @@
 #[cfg(target_os = "macos")] pub use self::macos as target;
 #[cfg(target_os = "freebsd")] pub use self::freebsd as target;
 #[cfg(target_os = "openbsd")] pub use self::openbsd as target;
+#[cfg(target_os = "netbsd")] pub use self::netbsd as target;
 #[cfg(target_os = "dragonfly")] pub use self::dragonfly as target;
 
 #[cfg(target_os = "linux")] pub mod linux;
@@ -12,4 +13,5 @@
 #[cfg(target_os = "macos")] pub mod macos;
 #[cfg(target_os = "freebsd")] pub mod freebsd;
 #[cfg(target_os = "openbsd")] pub mod openbsd;
+#[cfg(target_os = "netbsd")] pub mod netbsd;
 #[cfg(target_os = "dragonfly")] pub mod dragonfly;

--- a/src/os/netbsd.rs
+++ b/src/os/netbsd.rs
@@ -1,0 +1,146 @@
+#![allow(non_camel_case_types)]
+
+use libc::{c_int,c_uint,c_uchar};
+
+pub type cc_t = c_uchar;
+pub type speed_t = c_uint;
+pub type tcflag_t = c_uint;
+
+#[derive(Debug,Copy,Clone,Eq,PartialEq)]
+#[repr(C)]
+pub struct termios {
+    pub c_iflag: tcflag_t,
+    pub c_oflag: tcflag_t,
+    pub c_cflag: tcflag_t,
+    pub c_lflag: tcflag_t,
+    pub c_cc: [cc_t; NCCS],
+    c_ispeed: speed_t,
+    c_ospeed: speed_t
+}
+
+pub const NCCS: usize = 20;
+
+// c_cc characters
+pub const VEOF:     usize = 0;
+pub const VEOL:     usize = 1;
+pub const VEOL2:    usize = 2;
+pub const VERASE:   usize = 3;
+pub const VWERASE:  usize = 4;
+pub const VKILL:    usize = 5;
+pub const VREPRINT: usize = 6;
+pub const VERASE2:  usize = 7;
+pub const VINTR:    usize = 8;
+pub const VQUIT:    usize = 9;
+pub const VSUSP:    usize = 10;
+pub const VSTART:   usize = 12;
+pub const VSTOP:    usize = 13;
+pub const VLNEXT:   usize = 14;
+pub const VDISCARD: usize = 15;
+pub const VMIN:     usize = 16;
+pub const VTIME:    usize = 17;
+
+// c_iflag bits
+pub const IGNBRK:  tcflag_t = 0x00000001;
+pub const BRKINT:  tcflag_t = 0x00000002;
+pub const IGNPAR:  tcflag_t = 0x00000004;
+pub const PARMRK:  tcflag_t = 0x00000008;
+pub const INPCK:   tcflag_t = 0x00000010;
+pub const ISTRIP:  tcflag_t = 0x00000020;
+pub const INLCR:   tcflag_t = 0x00000040;
+pub const IGNCR:   tcflag_t = 0x00000080;
+pub const ICRNL:   tcflag_t = 0x00000100;
+pub const IXON:    tcflag_t = 0x00000200;
+pub const IXOFF:   tcflag_t = 0x00000400;
+pub const IXANY:   tcflag_t = 0x00000800;
+pub const IMAXBEL: tcflag_t = 0x00002000;
+
+// c_oflag bits
+pub const OPOST:  tcflag_t = 0x00000001;
+pub const ONLCR:  tcflag_t = 0x00000002;
+pub const TAB3:   tcflag_t = 0x00000004;
+pub const OXTABS: tcflag_t = TAB3;
+pub const ONOEOT: tcflag_t = 0x00000008;
+pub const OCRNL:  tcflag_t = 0x00000010;
+pub const ONOCR:  tcflag_t = 0x00000040;
+pub const ONLRET: tcflag_t = 0x00000080;
+
+// c_cflag bits
+pub const CIGNORE:    tcflag_t = 0x00000001;
+pub const CSIZE:      tcflag_t = 0x00000300;
+pub const CS5:        tcflag_t = 0x00000000;
+pub const CS6:        tcflag_t = 0x00000100;
+pub const CS7:        tcflag_t = 0x00000200;
+pub const CS8:        tcflag_t = 0x00000300;
+pub const CSTOPB:     tcflag_t = 0x00000400;
+pub const CREAD:      tcflag_t = 0x00000800;
+pub const PARENB:     tcflag_t = 0x00001000;
+pub const PARODD:     tcflag_t = 0x00002000;
+pub const HUPCL:      tcflag_t = 0x00004000;
+pub const CLOCAL:     tcflag_t = 0x00008000;
+pub const CRTSCTS:    tcflag_t = 0x00010000;
+pub const CRTS_IFLOW: tcflag_t = CRTSCTS;
+pub const CCTS_OFLOW: tcflag_t = CRTSCTS;
+pub const MDMBUF:     tcflag_t = 0x00100000;
+
+// c_lflag bits
+pub const ECHOKE:     tcflag_t = 0x00000001;
+pub const ECHOE:      tcflag_t = 0x00000002;
+pub const ECHOK:      tcflag_t = 0x00000004;
+pub const ECHO:       tcflag_t = 0x00000008;
+pub const ECHONL:     tcflag_t = 0x00000010;
+pub const ECHOPRT:    tcflag_t = 0x00000020;
+pub const ECHOCTL:    tcflag_t = 0x00000040;
+pub const ISIG:       tcflag_t = 0x00000080;
+pub const ICANON:     tcflag_t = 0x00000100;
+pub const ALTWERASE:  tcflag_t = 0x00000200;
+pub const IEXTEN:     tcflag_t = 0x00000400;
+pub const EXTPROC:    tcflag_t = 0x00000800;
+pub const TOSTOP:     tcflag_t = 0x00400000;
+pub const FLUSHO:     tcflag_t = 0x00800000;
+pub const NOKERNINFO: tcflag_t = 0x02000000;
+pub const PENDIN:     tcflag_t = 0x20000000;
+pub const NOFLSH:     tcflag_t = 0x80000000;
+
+// baud rates
+pub const B0:      speed_t = 0;
+pub const B50:     speed_t = 50;
+pub const B75:     speed_t = 75;
+pub const B110:    speed_t = 110;
+pub const B134:    speed_t = 134;
+pub const B150:    speed_t = 150;
+pub const B200:    speed_t = 200;
+pub const B300:    speed_t = 300;
+pub const B600:    speed_t = 600;
+pub const B1200:   speed_t = 1200;
+pub const B1800:   speed_t = 1800;
+pub const B2400:   speed_t = 2400;
+pub const B4800:   speed_t = 4800;
+pub const B9600:   speed_t = 9600;
+pub const B19200:  speed_t = 19200;
+pub const B38400:  speed_t = 38400;
+pub const B7200:   speed_t = 7200;
+pub const B14400:  speed_t = 14400;
+pub const B28800:  speed_t = 28800;
+pub const B57600:  speed_t = 57600;
+pub const B76800:  speed_t = 76800;
+pub const B115200: speed_t = 115200;
+pub const B230400: speed_t = 230400;
+pub const EXTA:    speed_t = 19200;
+pub const EXTB:    speed_t = 38400;
+
+// tcflow()
+pub const TCOOFF: c_int = 1;
+pub const TCOON:  c_int = 2;
+pub const TCIOFF: c_int = 3;
+pub const TCION:  c_int = 4;
+
+// tcflush()
+pub const TCIFLUSH:  c_int = 1;
+pub const TCOFLUSH:  c_int = 2;
+pub const TCIOFLUSH: c_int = 3;
+
+// tcsetattr()
+pub const TCSANOW:   c_int = 0;
+pub const TCSADRAIN: c_int = 1;
+pub const TCSAFLUSH: c_int = 2;
+pub const TCSASOFT:  c_int = 0x10;

--- a/src/os/netbsd.rs
+++ b/src/os/netbsd.rs
@@ -38,6 +38,8 @@ pub const VLNEXT:   usize = 14;
 pub const VDISCARD: usize = 15;
 pub const VMIN:     usize = 16;
 pub const VTIME:    usize = 17;
+pub const VSTATUS:  usize = 18;
+// 19 is "spare"
 
 // c_iflag bits
 pub const IGNBRK:  tcflag_t = 0x00000001;
@@ -57,12 +59,11 @@ pub const IMAXBEL: tcflag_t = 0x00002000;
 // c_oflag bits
 pub const OPOST:  tcflag_t = 0x00000001;
 pub const ONLCR:  tcflag_t = 0x00000002;
-pub const TAB3:   tcflag_t = 0x00000004;
-pub const OXTABS: tcflag_t = TAB3;
+pub const OXTABS: tcflag_t = 0x00000004;
 pub const ONOEOT: tcflag_t = 0x00000008;
 pub const OCRNL:  tcflag_t = 0x00000010;
-pub const ONOCR:  tcflag_t = 0x00000040;
-pub const ONLRET: tcflag_t = 0x00000080;
+pub const ONOCR:  tcflag_t = 0x00000020;
+pub const ONLRET: tcflag_t = 0x00000040;
 
 // c_cflag bits
 pub const CIGNORE:    tcflag_t = 0x00000001;
@@ -81,6 +82,10 @@ pub const CRTSCTS:    tcflag_t = 0x00010000;
 pub const CRTS_IFLOW: tcflag_t = CRTSCTS;
 pub const CCTS_OFLOW: tcflag_t = CRTSCTS;
 pub const MDMBUF:     tcflag_t = 0x00100000;
+// NetBSD defines CHFLOW as this:
+// pub const CHFLOW:     tcflag_t = (MDMBUF|CRTSCTS|CDTRCTS);
+// Pick one and be consistent with above
+pub const CHFLOW:     tcflag_t = CRTSCTS;
 
 // c_lflag bits
 pub const ECHOKE:     tcflag_t = 0x00000001;
@@ -125,6 +130,8 @@ pub const B57600:  speed_t = 57600;
 pub const B76800:  speed_t = 76800;
 pub const B115200: speed_t = 115200;
 pub const B230400: speed_t = 230400;
+pub const B460800: speed_t = 460800;
+pub const B921600: speed_t = 921600;
 pub const EXTA:    speed_t = 19200;
 pub const EXTB:    speed_t = 38400;
 


### PR DESCRIPTION
Opening this PR just to get it underway, there are some things I still need to check.

In general copying OpenBSD stuff for NetBSD is a fairly safe bet, but I'm a bit confused over the baud rate stuff. To get the tests to pass I had to use a lower baud rate (9600 vs 230400) and yet if I check `/usr/include/termios.h` and `/usr/include/sys/termios.h` I see those there:

```
/*
 * Standard speeds
 */
#define B0      0U
#define B50     50U
#define B75     75U
#define B110    110U
#define B134    134U
#define B150    150U
#define B200    200U
#define B300    300U
#define B600    600U
#define B1200   1200U
#define B1800   1800U
#define B2400   2400U
#define B4800   4800U
#define B9600   9600U
#define B19200  19200U
#define B38400  38400U
#if defined(_NETBSD_SOURCE)
#define B7200   7200U
#define B14400  14400U
#define B28800  28800U
#define B57600  57600U
#define B76800  76800U
#define B115200 115200U
#define B230400 230400U
#define B460800 460800U
#define B921600 921600U
#define EXTA    19200U
#define EXTB    38400U
#endif  /* defined(_NETBSD_SOURCE) */
```

This does currently build and work as part of a parent crate I'm using though.