### PR TITLE
Add Haiku support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ termios definitions for the following platforms:
 * NetBSD (amd64)
 * DragonFly BSD (x86_64)
 * illumos (x86_64)
+* Haiku (x86_64)
 
 If you're interested in a platform that's not listed here, please see
 [`CONTRIBUTING.md`](CONTRIBUTING.md) to see how you can help.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,7 +16,7 @@ extern "C" {
     pub fn cfgetospeed(termios_p: *const ::os::target::termios) -> ::os::target::speed_t;
     pub fn cfsetispeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
     pub fn cfsetospeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
-    #[cfg(not(target_os = "solaris"))]
+    #[cfg(all(not(target_os = "solaris"), not(target_os = "haiku")))]
     pub fn cfsetspeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int;
     pub fn tcgetsid(fd: c_int) -> pid_t;
 }
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn cfmakeraw(termios: *mut ::os::target::termios) {
     (*termios).c_cc[VTIME] = 0;
 }
 
-#[cfg(target_os = "solaris")]
+#[cfg(any(target_os = "solaris", target_os = "haiku"))]
 #[no_mangle]
 pub unsafe extern "C" fn cfsetspeed(termios_p: *mut ::os::target::termios, speed: ::os::target::speed_t) -> c_int {
     match cfsetispeed(termios_p, speed) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,11 @@
 //!     cfsetspeed(termios, termios::os::solaris::B921600)
 //! }
 //!
+//! #[cfg(target_os = "haiku")]
+//! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
+//!     cfsetspeed(termios, termios::os::haiku::B230400)
+//! }
+//!
 //! # let fd = 1;
 //! let mut termios = Termios::from_fd(fd).unwrap();
 //! set_fastest_speed(&mut termios).unwrap();

--- a/src/os/haiku.rs
+++ b/src/os/haiku.rs
@@ -1,0 +1,157 @@
+#![allow(non_camel_case_types)]
+
+use libc::{c_int,c_uchar};
+
+pub type cc_t = c_uchar;
+pub type speed_t = c_uchar;
+pub type tcflag_t = u32;
+
+#[derive(Debug,Copy,Clone,Eq,PartialEq)]
+#[repr(C)]
+pub struct termios {
+    pub c_iflag: tcflag_t,
+    pub c_oflag: tcflag_t,
+    pub c_cflag: tcflag_t,
+    pub c_lflag: tcflag_t,
+    c_line: cc_t,
+    c_ispeed: speed_t,
+    c_ospeed: speed_t,
+    pub c_cc: [cc_t; NCCS]
+}
+
+pub const NCCS: usize = 11;
+
+// c_cc characters
+pub const VINTR:    usize = 0;
+pub const VQUIT:    usize = 1;
+pub const VERASE:   usize = 2;
+pub const VKILL:    usize = 3;
+pub const VEOF:     usize = 4;
+pub const VEOL:     usize = 5;
+pub const VMIN:     usize = 4;
+pub const VTIME:    usize = 5;
+pub const VEOL2:    usize = 6;
+pub const VSWTCH:   usize = 7;
+pub const VSTART:   usize = 8;
+pub const VSTOP:    usize = 9;
+pub const VSUSP:    usize = 10;
+
+// c_iflag bits
+pub const IGNBRK:  tcflag_t = 0x01;
+pub const BRKINT:  tcflag_t = 0x02;
+pub const IGNPAR:  tcflag_t = 0x04;
+pub const PARMRK:  tcflag_t = 0x08;
+pub const INPCK:   tcflag_t = 0x10;
+pub const ISTRIP:  tcflag_t = 0x20;
+pub const INLCR:   tcflag_t = 0x40;
+pub const IGNCR:   tcflag_t = 0x80;
+pub const ICRNL:   tcflag_t = 0x100;
+pub const IUCLC:   tcflag_t = 0x200;
+pub const IXON:    tcflag_t = 0x400;
+pub const IXANY:   tcflag_t = 0x800;
+pub const IXOFF:   tcflag_t = 0x1000;
+
+// c_oflag bits
+pub const OPOST:  tcflag_t = 0x01;
+pub const OLCUC:  tcflag_t = 0x02;
+pub const ONLCR:  tcflag_t = 0x04;
+pub const OCRNL:  tcflag_t = 0x08;
+pub const ONOCR:  tcflag_t = 0x10;
+pub const ONLRET: tcflag_t = 0x20;
+pub const OFILL:  tcflag_t = 0x40;
+pub const OFDEL:  tcflag_t = 0x80;
+pub const NLDLY:  tcflag_t = 0x100;
+pub const NL0:    tcflag_t = 0x000;
+pub const NL1:    tcflag_t = 0x100;
+pub const CRDLY:  tcflag_t = 0x600;
+pub const CR0:    tcflag_t = 0x000;
+pub const CR1:    tcflag_t = 0x200;
+pub const CR2:    tcflag_t = 0x400;
+pub const CR3:    tcflag_t = 0x600;
+pub const TABDLY: tcflag_t = 0x1800;
+pub const TAB0:   tcflag_t = 0x0000;
+pub const TAB1:   tcflag_t = 0x0800;
+pub const TAB2:   tcflag_t = 0x1000;
+pub const TAB3:   tcflag_t = 0x1800;
+pub const BSDLY:  tcflag_t = 0x2000;
+pub const BS0:    tcflag_t = 0x0000;
+pub const BS1:    tcflag_t = 0x2000;
+pub const VTDLY:  tcflag_t = 0x4000;
+pub const VT0:    tcflag_t = 0x0000;
+pub const VT1:    tcflag_t = 0x4000;
+pub const FFDLY:  tcflag_t = 0x8000;
+pub const FF0:    tcflag_t = 0x0000;
+pub const FF1:    tcflag_t = 0x8000;
+
+// c_cflag bits
+pub const CBAUD:    tcflag_t = 0x1F;
+pub const CSIZE:    tcflag_t = 0x20;
+pub const CS5:      tcflag_t = 0x00;
+pub const CS6:      tcflag_t = 0x00;
+pub const CS7:      tcflag_t = 0x00;
+pub const CS8:      tcflag_t = 0x20;
+pub const CSTOPB:   tcflag_t = 0x40;
+pub const CREAD:    tcflag_t = 0x80;
+pub const PARENB:   tcflag_t = 0x100;
+pub const PARODD:   tcflag_t = 0x200;
+pub const HUPCL:    tcflag_t = 0x400;
+pub const CLOCAL:   tcflag_t = 0x800;
+pub const XLOBLK:   tcflag_t = 0x1000;
+pub const CTSFLOW:  tcflag_t = 0x2000;
+pub const RTSFLOW:  tcflag_t = 0x4000;
+pub const CRTSCTS:  tcflag_t = RTSFLOW | CTSFLOW;
+
+// c_lflag bits
+pub const ISIG:    tcflag_t = 0x01;
+pub const ICANON:  tcflag_t = 0x02;
+pub const XCASE:   tcflag_t = 0x04;
+pub const ECHO:    tcflag_t = 0x08;
+pub const ECHOE:   tcflag_t = 0x10;
+pub const ECHOK:   tcflag_t = 0x20;
+pub const ECHONL:  tcflag_t = 0x40;
+pub const NOFLSH:  tcflag_t = 0x80;
+pub const TOSTOP:  tcflag_t = 0x100;
+pub const IEXTEN:  tcflag_t = 0x200;
+pub const ECHOCTL: tcflag_t = 0x400;
+pub const ECHOPRT: tcflag_t = 0x800;
+pub const ECHOKE:  tcflag_t = 0x1000;
+pub const FLUSHO:  tcflag_t = 0x2000;
+pub const PENDIN:  tcflag_t = 0x4000;
+
+// baud rates
+pub const B0:       speed_t = 0x00;
+pub const B50:      speed_t = 0x01;
+pub const B75:      speed_t = 0x02;
+pub const B110:     speed_t = 0x03;
+pub const B134:     speed_t = 0x04;
+pub const B150:     speed_t = 0x05;
+pub const B200:     speed_t = 0x06;
+pub const B300:     speed_t = 0x07;
+pub const B600:     speed_t = 0x08;
+pub const B1200:    speed_t = 0x09;
+pub const B1800:    speed_t = 0x0A;
+pub const B2400:    speed_t = 0x0B;
+pub const B4800:    speed_t = 0x0C;
+pub const B9600:    speed_t = 0x0D;
+pub const B19200:   speed_t = 0x0E;
+pub const B38400:   speed_t = 0x0F;
+pub const B57600:   speed_t = 0x10;
+pub const B115200:  speed_t = 0x11;
+pub const B230400:  speed_t = 0x12;
+pub const B31250:   speed_t = 0x13;
+
+// tcsetattr()
+pub const TCSANOW:   c_int = 0x01;
+pub const TCSADRAIN: c_int = 0x02;
+pub const TCSAFLUSH: c_int = 0x04;
+
+// tcflow()
+pub const TCOOFF: c_int = 0x01;
+pub const TCOON:  c_int = 0x02;
+pub const TCIOFF: c_int = 0x04;
+pub const TCION:  c_int = 0x08;
+
+// tcflush()
+pub const TCIFLUSH:  c_int = 0x01;
+pub const TCOFLUSH:  c_int = 0x02;
+pub const TCIOFLUSH: c_int = 0x03;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -8,6 +8,7 @@
 #[cfg(target_os = "netbsd")] pub use self::netbsd as target;
 #[cfg(target_os = "dragonfly")] pub use self::dragonfly as target;
 #[cfg(target_os = "solaris")] pub use self::solaris as target;
+#[cfg(target_os = "haiku")] pub use self::haiku as target;
 
 #[cfg(target_os = "linux")] pub mod linux;
 #[cfg(target_os = "android")] pub mod android;
@@ -17,3 +18,4 @@
 #[cfg(target_os = "netbsd")] pub mod netbsd;
 #[cfg(target_os = "dragonfly")] pub mod dragonfly;
 #[cfg(target_os = "solaris")] pub mod solaris;
+#[cfg(target_os = "haiku")] pub mod haiku;


### PR DESCRIPTION
This is #24 with some fixes:

* Redefined `tcflag_t` as `u32`. It's typedef'd as `__haiku_uint32` in `termios.h`. I think `u32` matches the intended use of that type.
* I provided an implementation for `cfsetspeed()`, because that seems to be missing in Haiku. Without it, anything that attempts to use `cfsetspeed()` will fail to link.

I need help testing this, though. If anyone's interested in landing support for Haiku, please help me verify its correctness. What I'm really looking for is some instructions on how to setup a working Rust compiler on Haiku. `pkgman install rust_bin` doesn't do it for me. `cargo` crashes with a segfault inside OpenSSL when fetching dependencies.

I wrote shiny new contributing guidelines earlier today with details on what kind of [testing guidance](https://github.com/dcuddeback/termios-rs/blob/master/CONTRIBUTING.md#testing-guidance) I'm looking for as well as how others might [help test](https://github.com/dcuddeback/termios-rs/blob/master/CONTRIBUTING.md#testing) a patch like this.

/cc @sikmir