### PR TITLE
Don't explicitly link with libc

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,7 +2,6 @@
 
 use libc::{c_int,pid_t};
 
-#[link(name = "c")]
 extern "C" {
     pub fn tcgetattr(fd: c_int, termios_p: *mut ::os::target::termios) -> c_int;
     pub fn tcsetattr(fd: c_int, optional_actions: c_int, termios_p: *const ::os::target::termios) -> c_int;


### PR DESCRIPTION
Otherwise cross compiled musl targets fail at runtime.
Libc is already included so linking libc isn't necessary,
at least testing on Ubuntu Linux.