### PR TITLE
Add Haiku support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ termios definitions for the following platforms:
 * NetBSD (amd64)
 * DragonFly BSD (x86_64)
 * illumos (x86_64)
+* Haiku (x86_64)
 
 If you're interested in a platform that's not listed here, please see
 [`CONTRIBUTING.md`](CONTRIBUTING.md) to see how you can help.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,11 @@
 //!     cfsetspeed(termios, termios::os::illumos::B921600)
 //! }
 //!
+//! #[cfg(target_os = "haiku")]
+//! fn set_fastest_speed(termios: &mut Termios) -> io::Result<()> {
+//!     cfsetspeed(termios, termios::os::haiku::B230400)
+//! }
+//!
 //! # let fd = 1;
 //! let mut termios = Termios::from_fd(fd).unwrap();
 //! set_fastest_speed(&mut termios).unwrap();

--- a/src/os/haiku.rs
+++ b/src/os/haiku.rs
@@ -1,0 +1,157 @@
+#![allow(non_camel_case_types)]
+
+use libc::{c_int,c_uchar};
+
+pub type cc_t = c_uchar;
+pub type speed_t = c_uchar;
+pub type tcflag_t = u32;
+
+#[derive(Debug,Copy,Clone,Eq,PartialEq)]
+#[repr(C)]
+pub struct termios {
+    pub c_iflag: tcflag_t,
+    pub c_oflag: tcflag_t,
+    pub c_cflag: tcflag_t,
+    pub c_lflag: tcflag_t,
+    c_line: cc_t,
+    c_ispeed: speed_t,
+    c_ospeed: speed_t,
+    pub c_cc: [cc_t; NCCS]
+}
+
+pub const NCCS: usize = 11;
+
+// c_cc characters
+pub const VINTR:    usize = 0;
+pub const VQUIT:    usize = 1;
+pub const VERASE:   usize = 2;
+pub const VKILL:    usize = 3;
+pub const VEOF:     usize = 4;
+pub const VEOL:     usize = 5;
+pub const VMIN:     usize = 4;
+pub const VTIME:    usize = 5;
+pub const VEOL2:    usize = 6;
+pub const VSWTCH:   usize = 7;
+pub const VSTART:   usize = 8;
+pub const VSTOP:    usize = 9;
+pub const VSUSP:    usize = 10;
+
+// c_iflag bits
+pub const IGNBRK:  tcflag_t = 0x01;
+pub const BRKINT:  tcflag_t = 0x02;
+pub const IGNPAR:  tcflag_t = 0x04;
+pub const PARMRK:  tcflag_t = 0x08;
+pub const INPCK:   tcflag_t = 0x10;
+pub const ISTRIP:  tcflag_t = 0x20;
+pub const INLCR:   tcflag_t = 0x40;
+pub const IGNCR:   tcflag_t = 0x80;
+pub const ICRNL:   tcflag_t = 0x100;
+pub const IUCLC:   tcflag_t = 0x200;
+pub const IXON:    tcflag_t = 0x400;
+pub const IXANY:   tcflag_t = 0x800;
+pub const IXOFF:   tcflag_t = 0x1000;
+
+// c_oflag bits
+pub const OPOST:  tcflag_t = 0x01;
+pub const OLCUC:  tcflag_t = 0x02;
+pub const ONLCR:  tcflag_t = 0x04;
+pub const OCRNL:  tcflag_t = 0x08;
+pub const ONOCR:  tcflag_t = 0x10;
+pub const ONLRET: tcflag_t = 0x20;
+pub const OFILL:  tcflag_t = 0x40;
+pub const OFDEL:  tcflag_t = 0x80;
+pub const NLDLY:  tcflag_t = 0x100;
+pub const NL0:    tcflag_t = 0x000;
+pub const NL1:    tcflag_t = 0x100;
+pub const CRDLY:  tcflag_t = 0x600;
+pub const CR0:    tcflag_t = 0x000;
+pub const CR1:    tcflag_t = 0x200;
+pub const CR2:    tcflag_t = 0x400;
+pub const CR3:    tcflag_t = 0x600;
+pub const TABDLY: tcflag_t = 0x1800;
+pub const TAB0:   tcflag_t = 0x0000;
+pub const TAB1:   tcflag_t = 0x0800;
+pub const TAB2:   tcflag_t = 0x1000;
+pub const TAB3:   tcflag_t = 0x1800;
+pub const BSDLY:  tcflag_t = 0x2000;
+pub const BS0:    tcflag_t = 0x0000;
+pub const BS1:    tcflag_t = 0x2000;
+pub const VTDLY:  tcflag_t = 0x4000;
+pub const VT0:    tcflag_t = 0x0000;
+pub const VT1:    tcflag_t = 0x4000;
+pub const FFDLY:  tcflag_t = 0x8000;
+pub const FF0:    tcflag_t = 0x0000;
+pub const FF1:    tcflag_t = 0x8000;
+
+// c_cflag bits
+pub const CBAUD:    tcflag_t = 0x1F;
+pub const CSIZE:    tcflag_t = 0x20;
+pub const CS5:      tcflag_t = 0x00;
+pub const CS6:      tcflag_t = 0x00;
+pub const CS7:      tcflag_t = 0x00;
+pub const CS8:      tcflag_t = 0x20;
+pub const CSTOPB:   tcflag_t = 0x40;
+pub const CREAD:    tcflag_t = 0x80;
+pub const PARENB:   tcflag_t = 0x100;
+pub const PARODD:   tcflag_t = 0x200;
+pub const HUPCL:    tcflag_t = 0x400;
+pub const CLOCAL:   tcflag_t = 0x800;
+pub const XLOBLK:   tcflag_t = 0x1000;
+pub const CTSFLOW:  tcflag_t = 0x2000;
+pub const RTSFLOW:  tcflag_t = 0x4000;
+pub const CRTSCTS:  tcflag_t = RTSFLOW | CTSFLOW;
+
+// c_lflag bits
+pub const ISIG:    tcflag_t = 0x01;
+pub const ICANON:  tcflag_t = 0x02;
+pub const XCASE:   tcflag_t = 0x04;
+pub const ECHO:    tcflag_t = 0x08;
+pub const ECHOE:   tcflag_t = 0x10;
+pub const ECHOK:   tcflag_t = 0x20;
+pub const ECHONL:  tcflag_t = 0x40;
+pub const NOFLSH:  tcflag_t = 0x80;
+pub const TOSTOP:  tcflag_t = 0x100;
+pub const IEXTEN:  tcflag_t = 0x200;
+pub const ECHOCTL: tcflag_t = 0x400;
+pub const ECHOPRT: tcflag_t = 0x800;
+pub const ECHOKE:  tcflag_t = 0x1000;
+pub const FLUSHO:  tcflag_t = 0x2000;
+pub const PENDIN:  tcflag_t = 0x4000;
+
+// baud rates
+pub const B0:       speed_t = 0x00;
+pub const B50:      speed_t = 0x01;
+pub const B75:      speed_t = 0x02;
+pub const B110:     speed_t = 0x03;
+pub const B134:     speed_t = 0x04;
+pub const B150:     speed_t = 0x05;
+pub const B200:     speed_t = 0x06;
+pub const B300:     speed_t = 0x07;
+pub const B600:     speed_t = 0x08;
+pub const B1200:    speed_t = 0x09;
+pub const B1800:    speed_t = 0x0A;
+pub const B2400:    speed_t = 0x0B;
+pub const B4800:    speed_t = 0x0C;
+pub const B9600:    speed_t = 0x0D;
+pub const B19200:   speed_t = 0x0E;
+pub const B38400:   speed_t = 0x0F;
+pub const B57600:   speed_t = 0x10;
+pub const B115200:  speed_t = 0x11;
+pub const B230400:  speed_t = 0x12;
+pub const B31250:   speed_t = 0x13;
+
+// tcsetattr()
+pub const TCSANOW:   c_int = 0x01;
+pub const TCSADRAIN: c_int = 0x02;
+pub const TCSAFLUSH: c_int = 0x04;
+
+// tcflow()
+pub const TCOOFF: c_int = 0x01;
+pub const TCOON:  c_int = 0x02;
+pub const TCIOFF: c_int = 0x04;
+pub const TCION:  c_int = 0x08;
+
+// tcflush()
+pub const TCIFLUSH:  c_int = 0x01;
+pub const TCOFLUSH:  c_int = 0x02;
+pub const TCIOFLUSH: c_int = 0x03;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -9,6 +9,7 @@
 #[cfg(target_os = "dragonfly")] pub use self::dragonfly as target;
 #[cfg(target_os = "solaris")] pub use self::solaris as target;
 #[cfg(target_os = "illumos")] pub use self::illumos as target;
+#[cfg(target_os = "haiku")] pub use self::haiku as target;
 
 #[cfg(target_os = "linux")] pub mod linux;
 #[cfg(target_os = "android")] pub mod android;
@@ -19,3 +20,4 @@
 #[cfg(target_os = "dragonfly")] pub mod dragonfly;
 #[cfg(target_os = "solaris")] pub mod solaris;
 #[cfg(target_os = "illumos")] pub mod illumos;
+#[cfg(target_os = "haiku")] pub mod haiku;


### PR DESCRIPTION
This is a rebase of #26 on the current sources with the following notes:

- There were merge conflicts due to adding Illumos support. Nothing really complicated to fix.
- Since this was initially developped, Haiku did get an implementation for cfsetspeed, so use that instead of the reimplementation.
- Confirmed building and passing tests on a current Haiku nightly build (as Haiku should be quite close to shipping a new beta release, I feel no need to support the soon deprecated beta 5).